### PR TITLE
Fix: Update commons-text to 1.13.1 and resolve jpackage module issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ tasks.withType(JavaExec) {
 dependencies {
     implementation 'com.miglayout:miglayout-swing:11.4.2'
     implementation 'com.miglayout:miglayout-core:11.4.2'
-    implementation 'org.apache.commons:commons-text:1.9' // jpackage doesn't like 1.10.0, 1.11.0 or 1.13.1.  1.9 works
+    implementation 'org.apache.commons:commons-text:1.13.1' // jpackage doesn't like 1.10.0, 1.11.0 or 1.13.1.  1.9 works
     implementation files('libs/tagcloud.library-0.0.1.jar')
     implementation 'org.apache.commons:commons-compress:1.27.1'
     implementation 'org.apache.commons:commons-jcs3:3.2.1'
@@ -297,6 +297,7 @@ jlink {
     // Try adding this to explicitly make sure it's seen by jlink
     //addExtraDependencies "org.apache.commons:commons-lang3:3.17.0" // Use the exact version you depend on
     //addExtraDependencies "org.apache.commons:commons-text:1.13.1" // Also ensure this is explicitly added
+    forceMerge 'commons-text'
 
     jpackage {
         var os = OperatingSystem.current()
@@ -306,7 +307,7 @@ jlink {
 
         outputDir = 'my-packaging'
         imageName = 'JPO'
-        skipInstaller = false
+        skipInstaller = true
         installerName = 'jpo'
         vendor = "Richard Eigenmann (project owner)"
         icon = 'src/web/favicon.ico'


### PR DESCRIPTION
I've updated org.apache.commons:commons-text from version 1.9 to 1.13.1.

The previous version (1.9) was an automatic module. Versions 1.10.0+ (including 1.13.1) are explicit, multi-release JPMS modules. This change caused the `:createMergedModule` task (from org.javamodularity.moduleplugin) to fail with "module not found: org.apache.commons.text" when preparing for jlink/jpackage.

This was resolved by adding `forceMerge 'commons-text'` to the `jlink` configuration block in `build.gradle`. This directive instructs the `org.beryx.jlink` plugin to treat `commons-text` as if it were non-modular for its own merged-module generation, bypassing the issue with the explicit module definition during the jlink phase.

Additionally, as per your request, `skipInstaller` in the `jpackage` configuration has been set to `true`. This ensures that `jpackage` only builds the application image and does not attempt to create installers, avoiding potential failures in environments lacking specific installer tools (e.g., for RPMs).

With these changes, `./gradlew jpackage` now successfully builds an application image with commons-text 1.13.1.