### PR TITLE
Okay, I've added some checks and logging to help us figure out that N…

### DIFF
--- a/src/main/java/org/jpo/datamodel/PictureInfo.java
+++ b/src/main/java/org/jpo/datamodel/PictureInfo.java
@@ -457,6 +457,7 @@ public class PictureInfo implements Serializable, GroupOrPicture {
      * @throws IOException if the underlying library encounters and {@link IOException}
      */
     public static String calculateSha256(final File file) throws IOException {
+        Objects.requireNonNull(file, "Cannot calculate SHA256 for a null file input in PictureInfo.calculateSha256");
         final var hash = Files.asByteSource(file).hash(Hashing.sha256());
         if (hash == null) {
             return "";

--- a/src/main/java/org/jpo/datamodel/SourcePicture.java
+++ b/src/main/java/org/jpo/datamodel/SourcePicture.java
@@ -15,6 +15,7 @@ import java.awt.image.AffineTransformOp;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
+import java.util.Objects;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.NoSuchElementException;
@@ -140,6 +141,7 @@ public class SourcePicture {
      * @param rotation Image rotation
      */
     public void loadPicture(final String sha256, final File file, final double rotation) {
+        Objects.requireNonNull(file, "file parameter must not be null in SourcePicture.loadPicture");
         if (pictureStatusCode.get() == SOURCE_PICTURE_LOADING) {
             stopLoadingExcept(file);
         }
@@ -159,6 +161,7 @@ public class SourcePicture {
      * @param rotation  The rotation 0-360 to be used on this picture
      */
     public void loadPictureInThread(final String sha256, final File imageFile, final int priority, final double rotation) {
+        Objects.requireNonNull(imageFile, "imageFile parameter must not be null in SourcePicture.loadPictureInThread");
         if (pictureStatusCode.get() == SOURCE_PICTURE_LOADING) {
             stopLoadingExcept(imageFile);
         }

--- a/src/test/java/org/jpo/export/WebsiteGeneratorTest.java
+++ b/src/test/java/org/jpo/export/WebsiteGeneratorTest.java
@@ -142,6 +142,7 @@ class WebsiteGeneratorTest {
             final var pictureNode = new SortableDefaultMutableTreeNode();
             final var imageFile = new File(ClassLoader.getSystemResources("exif-test-nikon-d100-1.jpg").nextElement().toURI());
             assertTrue(imageFile.canRead());
+            LOGGER.log(Level.INFO, "Test image file absolute path: {0}", imageFile.getAbsolutePath());
             final var pictureInfo = new PictureInfo(imageFile, "Image 1");
             pictureNode.setUserObject(pictureInfo);
             groupNode.add(pictureNode);


### PR DESCRIPTION
…ullPointerException.

I put in `Objects.requireNonNull` checks in `PictureInfo.calculateSha256` and both `SourcePicture.loadPicture` and `loadPictureInThread`. This way, if a `File` object is null, you'll get a much clearer error message.

I also added some logging in `WebsiteGeneratorTest` so it will now output the absolute path of the test image file. This should help us see if there are any path resolution issues when running in different CI environments.

Hopefully, these changes will help us find exactly where that NullPointerException is coming from in `PictureInfo.calculateSha256` during the `testGenerateWebsite` test in CircleCI.